### PR TITLE
Add bash preamble

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ public/
 build/*
 !build/*.do
 .redo
+node_modules
+ui/node_modules

--- a/all.do
+++ b/all.do
@@ -1,1 +1,2 @@
+#!/usr/bin/env bash
 redo build/public.tree

--- a/build/all.js.do
+++ b/build/all.js.do
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 redo-ifchange mode wasm.js
 mode=$(cat mode)
 

--- a/build/default.checksum.do
+++ b/build/default.checksum.do
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 redo-ifchange $2
 
 extension="${2##*.}"

--- a/build/default.html.do
+++ b/build/default.html.do
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 source=$2
 page=$source
 toc=normal

--- a/build/main.css.do
+++ b/build/main.css.do
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 redo-ifchange mode
 mode=$(cat mode)
 

--- a/build/mode.do
+++ b/build/mode.do
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 echo ${BUILD_MODE:-dev} >$3
 redo-always
 redo-stamp <$3

--- a/build/public.tree.do
+++ b/build/public.tree.do
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 redo-ifchange main.css{,.checksum} all.js{,.checksum}
 
 css=$(< main.css.checksum)

--- a/build/toodles.jimage.do
+++ b/build/toodles.jimage.do
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 actual_outpath_jfc=$PWD/$3
 cd ..
 

--- a/build/wasm.js.do
+++ b/build/wasm.js.do
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 redo-ifchange mode
 mode=$(cat mode)
 

--- a/clean.do
+++ b/clean.do
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 redo-always
 files=$(git ls-files build/ --ignored --exclude-standard -o)
 


### PR DESCRIPTION
This adds `#!/usr/bin/env bash` to all *.do scripts. This fixes #3 on OSX.

(Not sure if you want this long term, but in case you do, here are the changes.)

